### PR TITLE
Fix confusion of minutes and hours in cron entry.

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -3,7 +3,7 @@ name: Gatsby Build and Deploy to gh-pages branch
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 20 * * *"
+    - cron: "20 0 * * *"
   push:
     branches:
       - main

--- a/.github/workflows/build_and_deploy_staging.yml
+++ b/.github/workflows/build_and_deploy_staging.yml
@@ -3,7 +3,7 @@ name: Gatsby Build and Deploy to gh-pages-staging branch
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 40 * * *"
+    - cron: "40 0 * * *"
   push:
     branches:
       - staging

--- a/.github/workflows/build_only.yml
+++ b/.github/workflows/build_only.yml
@@ -3,7 +3,7 @@ name: Gatsby Build
 on:
   workflow_dispatch:
   schedule:
-    - cron: "1 10 * * *"
+    - cron: "10 1 * * *"
   push:
     branches-ignore:
       - main


### PR DESCRIPTION
Stupid mistake ...
Broke `build_and_deploy_staging.yaml` job, as it had an invalid hour setting (40).