### PR TITLE
Fix links to S7n.

### DIFF
--- a/src/content/de/pages/network.md
+++ b/src/content/de/pages/network.md
@@ -38,7 +38,7 @@ Das Forum SCS-Standards und die Entwicklung des SCS werden von einer Vielzahl an
 - [noris network AG](https://www.noris.de)
 - [OSISM GmbH](https://osism.tech)
 - [plusserver GmbH](https://plusserver.com)
-- [S7n Cloud Services GmbH](https://garloff.de/s7n/)
+- [S7n Cloud Services GmbH](https://www.garloff.de/s7n/)
 - [ScaleUp Technologies GmbH & Co. KG](https://scaleuptech.com)
 - [secunet Security Networks AG](https://secunet.com)
 - [STACKXPERTS GmbH](https://stackxperts.com)

--- a/src/content/en/pages/network.md
+++ b/src/content/en/pages/network.md
@@ -38,7 +38,7 @@ The Forum SCS-Standards and the development of SCS are supported by a wide range
 - [noris network AG](https://www.noris.de/en)
 - [OSISM GmbH](https://osism.tech)
 - [plusserver GmbH](https://plusserver.com)
-- [S7n Cloud Services GmbH](https://garloff.de/s7n/)
+- [S7n Cloud Services GmbH](https://www.garloff.de/s7n/)
 - [ScaleUp Technologies GmbH & Co. KG](https://scaleuptech.com)
 - [secunet Security Networks AG](https://secunet.com)
 - [STACKXPERTS GmbH](https://stackxperts.com)


### PR DESCRIPTION
Unlike with most sites, the `www` in `https://www.garloff.de/s7n/` is required. So add it.